### PR TITLE
Copia de Telas com alterações nos nomes das Labels

### DIFF
--- a/infra/Instruçoes.txt
+++ b/infra/Instruçoes.txt
@@ -33,7 +33,8 @@
 		RegExtMotive
 	Copiar e colar os componentes
 
-3 - Trocar componentes TDB por T
+3 - Mudar o name dos componentes e trocar TDB por T  
+	cline no componente e va ate name, altere para o mesmo name de outro componente vinculado
 	clique no form como botão direito do mouse no menu suspenso view as text
 	USar o Ctrl + R para fazer o Replace
 	clique no texto como botão direito do mouse no menu suspenso view as form

--- a/view/module/operation/register/reg_banner_site.dfm
+++ b/view/module/operation/register/reg_banner_site.dfm
@@ -1,84 +1,89 @@
 inherited RegBannerSite: TRegBannerSite
   Caption = 'Cadastro de Bannar para Site'
   ClientHeight = 423
-  ExplicitWidth = 815
+  ClientWidth = 809
   ExplicitHeight = 486
   TextHeight = 13
   inherited pnl_botao: TPanel
     Top = 359
+    Width = 809
     ExplicitTop = 350
-    ExplicitWidth = 797
+    ExplicitWidth = 803
     inherited SB_Inserir: TSpeedButton
-      Left = 176
+      Left = 182
       ExplicitLeft = 176
     end
     inherited SB_Alterar: TSpeedButton
-      Left = 280
+      Left = 286
       ExplicitLeft = 280
     end
     inherited SB_Excluir: TSpeedButton
-      Left = 384
+      Left = 390
       ExplicitLeft = 384
     end
     inherited SB_Cancelar: TSpeedButton
-      Left = 592
+      Left = 598
       ExplicitLeft = 592
     end
     inherited SB_Sair_0: TSpeedButton
-      Left = 696
+      Left = 702
       ExplicitLeft = 696
     end
     inherited SB_Gravar: TSpeedButton
-      Left = 488
+      Left = 494
       ExplicitLeft = 488
     end
   end
   inherited pnl_fundo: TPanel
+    Width = 809
     Height = 359
-    ExplicitWidth = 797
+    ExplicitWidth = 803
     ExplicitHeight = 350
     object img_amostra: TImage
       Left = 2
       Top = 113
-      Width = 799
+      Width = 805
       Height = 200
       Align = alClient
       Center = True
       ExplicitTop = 114
+      ExplicitWidth = 799
       ExplicitHeight = 223
     end
     object Image1: TImage
       Left = 2
       Top = 113
-      Width = 799
+      Width = 805
       Height = 200
       Align = alClient
       Center = True
       ExplicitLeft = 4
       ExplicitTop = 115
+      ExplicitWidth = 799
       ExplicitHeight = 223
     end
     object Image2: TImage
       Left = 2
       Top = 113
-      Width = 799
+      Width = 805
       Height = 200
       Align = alClient
       Center = True
       ExplicitLeft = 4
       ExplicitTop = 115
+      ExplicitWidth = 799
       ExplicitHeight = 223
     end
     object pnl_fundos: TPanel
       Left = 2
       Top = 2
-      Width = 799
+      Width = 805
       Height = 111
       Align = alTop
       BevelInner = bvRaised
       BevelOuter = bvLowered
       TabOrder = 0
-      ExplicitWidth = 793
+      ExplicitWidth = 799
       object Sb_Carr_Imagem: TSpeedButton
         Left = 663
         Top = 29
@@ -94,7 +99,7 @@ inherited RegBannerSite: TRegBannerSite
         NumGlyphs = 4
         ParentFont = False
       end
-      object Label34: TLabel
+      object Lb_Caminho: TLabel
         Left = 5
         Top = 9
         Width = 196
@@ -107,12 +112,13 @@ inherited RegBannerSite: TRegBannerSite
         Font.Style = []
         ParentFont = False
       end
-      object Label3: TLabel
+      object Lb_link: TLabel
         Left = 237
         Top = 56
         Width = 119
         Height = 14
         Caption = 'link do Banner (opcional)'
+        Enabled = False
         Font.Charset = ANSI_CHARSET
         Font.Color = clNavy
         Font.Height = -11
@@ -166,14 +172,14 @@ inherited RegBannerSite: TRegBannerSite
     object Panel2: TPanel
       Left = 2
       Top = 313
-      Width = 799
+      Width = 805
       Height = 44
       Align = alBottom
       BevelInner = bvRaised
       BevelOuter = bvLowered
       TabOrder = 1
       ExplicitTop = 304
-      ExplicitWidth = 793
+      ExplicitWidth = 799
       object Sb_First: TSpeedButton
         Left = 9
         Top = 4

--- a/view/module/operation/register/reg_banner_site.pas
+++ b/view/module/operation/register/reg_banner_site.pas
@@ -11,8 +11,8 @@ type
   TRegBannerSite = class(TBaseRegistry)
     pnl_fundos: TPanel;
     Sb_Carr_Imagem: TSpeedButton;
-    Label34: TLabel;
-    Label3: TLabel;
+    Lb_Caminho: TLabel;
+    Lb_link: TLabel;
     E_PathIMG: TEdit;
     Rg_ImageTarget: TRadioGroup;
     E_link: TEdit;

--- a/view/module/operation/register/reg_category.dfm
+++ b/view/module/operation/register/reg_category.dfm
@@ -69,7 +69,7 @@ inherited RegCategory: TRegCategory
       TabOrder = 0
       ExplicitWidth = 561
       ExplicitHeight = 172
-      object Label1: TLabel
+      object Lb_Codigo: TLabel
         Left = 5
         Top = 8
         Width = 33
@@ -83,7 +83,7 @@ inherited RegCategory: TRegCategory
         Font.Style = []
         ParentFont = False
       end
-      object Label2: TLabel
+      object Lb_Descricao: TLabel
         Left = 57
         Top = 8
         Width = 49
@@ -97,12 +97,13 @@ inherited RegCategory: TRegCategory
         Font.Style = []
         ParentFont = False
       end
-      object Label4: TLabel
+      object Lb_CategoriaPai: TLabel
         Left = 5
         Top = 49
         Width = 63
         Height = 14
         Caption = 'Categoria Pai'
+        Enabled = False
         FocusControl = E_Descricao
         Font.Charset = ANSI_CHARSET
         Font.Color = clNavy
@@ -111,7 +112,7 @@ inherited RegCategory: TRegCategory
         Font.Style = []
         ParentFont = False
       end
-      object Label5: TLabel
+      object Lb_Atendimento: TLabel
         Left = 5
         Top = 87
         Width = 178
@@ -131,7 +132,7 @@ inherited RegCategory: TRegCategory
         Height = 22
         Caption = '...'
       end
-      object Label6: TLabel
+      object Lb_Impressora: TLabel
         Left = 256
         Top = 87
         Width = 156
@@ -144,7 +145,7 @@ inherited RegCategory: TRegCategory
         Font.Style = []
         ParentFont = False
       end
-      object Label7: TLabel
+      object Lb_Interface: TLabel
         Left = 6
         Top = 127
         Width = 81
@@ -226,5 +227,9 @@ inherited RegCategory: TRegCategory
           'LISTA')
       end
     end
+  end
+  inherited Menu: TMainMenu
+    Left = 200
+    Top = 65520
   end
 end

--- a/view/module/operation/register/reg_category.pas
+++ b/view/module/operation/register/reg_category.pas
@@ -10,13 +10,13 @@ uses
 type
   TRegCategory = class(TBaseRegistry)
     pnl_fundos: TPanel;
-    Label1: TLabel;
-    Label2: TLabel;
-    Label4: TLabel;
-    Label5: TLabel;
+    Lb_Codigo: TLabel;
+    Lb_Descricao: TLabel;
+    Lb_CategoriaPai: TLabel;
+    Lb_Atendimento: TLabel;
     Sb_Impressora: TSpeedButton;
-    Label6: TLabel;
-    Label7: TLabel;
+    Lb_Impressora: TLabel;
+    Lb_Interface: TLabel;
     E_Codigo: TEdit;
     E_Descricao: TEdit;
     Dblcb_CategoriaPai: TComboBox;

--- a/view/module/operation/register/reg_electronic_slip.dfm
+++ b/view/module/operation/register/reg_electronic_slip.dfm
@@ -1,59 +1,59 @@
 inherited RegElectronicSlip: TRegElectronicSlip
-  Caption = 'Pesquisa de Cobran'#231'a em Boleto'
-  ClientHeight = 383
-  ClientWidth = 573
-  ExplicitWidth = 585
-  ExplicitHeight = 446
+  Caption = 'Cadastro para Cobran'#231'a em Boleto'
+  ClientHeight = 553
+  ClientWidth = 580
+  ExplicitWidth = 592
+  ExplicitHeight = 616
   TextHeight = 13
   inherited pnl_botao: TPanel
-    Top = 319
-    Width = 573
-    ExplicitTop = 310
-    ExplicitWidth = 567
+    Top = 489
+    Width = 580
+    ExplicitTop = 480
+    ExplicitWidth = 574
     inherited SB_Inserir: TSpeedButton
-      Left = -54
-      ExplicitLeft = -54
+      Left = -47
+      ExplicitLeft = -47
     end
     inherited SB_Alterar: TSpeedButton
-      Left = 50
-      ExplicitLeft = 50
+      Left = 57
+      ExplicitLeft = 57
     end
     inherited SB_Excluir: TSpeedButton
-      Left = 154
-      ExplicitLeft = 154
+      Left = 161
+      ExplicitLeft = 161
     end
     inherited SB_Cancelar: TSpeedButton
-      Left = 362
-      ExplicitLeft = 362
+      Left = 369
+      ExplicitLeft = 369
     end
     inherited SB_Sair_0: TSpeedButton
-      Left = 466
-      ExplicitLeft = 466
+      Left = 473
+      ExplicitLeft = 473
     end
     inherited SB_Gravar: TSpeedButton
-      Left = 258
-      ExplicitLeft = 258
+      Left = 265
+      ExplicitLeft = 265
     end
   end
   inherited pnl_fundo: TPanel
-    Width = 573
-    Height = 319
-    ExplicitWidth = 567
-    ExplicitHeight = 310
+    Width = 580
+    Height = 489
+    ExplicitWidth = 574
+    ExplicitHeight = 480
     object Pnl_fundos: TPanel
       Left = 2
       Top = 2
-      Width = 569
-      Height = 315
+      Width = 576
+      Height = 485
       Align = alClient
       BevelInner = bvRaised
       BevelOuter = bvLowered
       TabOrder = 0
-      ExplicitWidth = 563
-      ExplicitHeight = 306
-      object Label1: TLabel
-        Left = 7
-        Top = 0
+      ExplicitWidth = 570
+      ExplicitHeight = 476
+      object Lb_Carteira: TLabel
+        Left = 15
+        Top = 16
         Width = 103
         Height = 14
         Caption = 'Carteira de Cobran'#231'a'
@@ -66,14 +66,14 @@ inherited RegElectronicSlip: TRegElectronicSlip
       end
       object Sb_Carteira: TSpeedButton
         Left = 208
-        Top = 13
+        Top = 53
         Width = 24
         Height = 22
         Caption = '...'
       end
-      object Label2: TLabel
-        Left = 151
-        Top = 38
+      object Lb_Cedente_Convenio: TLabel
+        Left = 159
+        Top = 54
         Width = 116
         Height = 14
         Caption = 'C'#243'd Cedente / Conv'#234'nio'
@@ -84,9 +84,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label4: TLabel
-        Left = 422
-        Top = 38
+      object Lb_Varia_Carteira: TLabel
+        Left = 430
+        Top = 54
         Width = 99
         Height = 14
         Caption = 'Varia'#231#227'o da Carteira'
@@ -97,9 +97,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label31: TLabel
-        Left = 8
-        Top = 112
+      object Lb_Modelo_Boleto: TLabel
+        Left = 16
+        Top = 128
         Width = 82
         Height = 14
         Caption = 'Modelo do Boleto'
@@ -112,9 +112,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         ParentColor = False
         ParentFont = False
       end
-      object Label5: TLabel
-        Left = 6
-        Top = 193
+      object Lb_Local_Pagamneto: TLabel
+        Left = 14
+        Top = 209
         Width = 107
         Height = 14
         Caption = 'Local para Pagamento'
@@ -125,9 +125,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label6: TLabel
-        Left = 6
-        Top = 229
+      object Lb_Inst_Pagamento_1: TLabel
+        Left = 14
+        Top = 245
         Width = 245
         Height = 14
         Caption = 'Instru'#231#227'o para Pagamento 1 - Remessa Registrada'
@@ -138,9 +138,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label7: TLabel
-        Left = 6
-        Top = 265
+      object Lb_Inst_Pagamento_2: TLabel
+        Left = 14
+        Top = 281
         Width = 245
         Height = 14
         Caption = 'Instru'#231#227'o para Pagamento 2 - Remessa Registrada'
@@ -151,9 +151,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label8: TLabel
-        Left = 6
-        Top = 343
+      object Lb_IntrucaoAdicional: TLabel
+        Left = 14
+        Top = 319
         Width = 90
         Height = 14
         Caption = 'Instru'#231#227'o adicional'
@@ -164,9 +164,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label10: TLabel
-        Left = 6
-        Top = 449
+      object Lb_Remessa_Retorno: TLabel
+        Left = 14
+        Top = 425
         Width = 270
         Height = 14
         Caption = 'Local de armazenamento arquivos de Remessa/Retorno'
@@ -190,9 +190,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label11: TLabel
-        Left = 342
-        Top = 150
+      object Lb_Tx_Multa: TLabel
+        Left = 350
+        Top = 166
         Width = 46
         Height = 14
         Caption = 'Multa (%)'
@@ -203,9 +203,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label12: TLabel
-        Left = 7
-        Top = 150
+      object Lb_Tx_Juros: TLabel
+        Left = 15
+        Top = 166
         Width = 74
         Height = 14
         Caption = 'Juros /M'#234's (%)'
@@ -216,9 +216,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label13: TLabel
-        Left = 97
-        Top = 75
+      object Lb_Protesto: TLabel
+        Left = 105
+        Top = 91
         Width = 72
         Height = 14
         Caption = 'Protestar T'#237'tulo'
@@ -229,22 +229,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label14: TLabel
-        Left = 94
-        Top = 150
-        Width = 63
-        Height = 14
-        Caption = 'Mora/Dia (%)'
-        Font.Charset = ANSI_CHARSET
-        Font.Color = clNavy
-        Font.Height = -11
-        Font.Name = 'Arial'
-        Font.Style = []
-        ParentFont = False
-      end
-      object Label15: TLabel
-        Left = 452
-        Top = 150
+      object Lb_Vl_Tarifa: TLabel
+        Left = 460
+        Top = 166
         Width = 55
         Height = 14
         Caption = 'Valor Tarifa'
@@ -255,9 +242,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label_1: TLabel
-        Left = 258
-        Top = 75
+      object Lb_Dias_Protesto: TLabel
+        Left = 266
+        Top = 91
         Width = 38
         Height = 14
         Caption = 'Nr Dias '
@@ -268,9 +255,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label17: TLabel
-        Left = 256
-        Top = 150
+      object Lb_Tx_Desconto: TLabel
+        Left = 264
+        Top = 166
         Width = 67
         Height = 14
         Caption = 'Desconto (%)'
@@ -281,9 +268,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label18: TLabel
-        Left = 176
-        Top = 150
+      object Lb_Vl_Mora_Min: TLabel
+        Left = 184
+        Top = 166
         Width = 59
         Height = 14
         Caption = 'Mora M'#237'nima'
@@ -294,9 +281,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label19: TLabel
-        Left = 5
-        Top = 75
+      object Lb_LayoutRemessa: TLabel
+        Left = 13
+        Top = 91
         Width = 81
         Height = 14
         Caption = 'Layout Remessa'
@@ -307,9 +294,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label20: TLabel
-        Left = 288
-        Top = 38
+      object Lb_CodTransmissao: TLabel
+        Left = 296
+        Top = 54
         Width = 98
         Height = 14
         Caption = 'C'#243'digo Transmiss'#227'o'
@@ -320,9 +307,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label3: TLabel
-        Left = 150
-        Top = 111
+      object Lb_Posto_Benef: TLabel
+        Left = 158
+        Top = 127
         Width = 87
         Height = 14
         Caption = 'Posto Benefici'#225'rio'
@@ -333,9 +320,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label9: TLabel
-        Left = 323
-        Top = 75
+      object Lb_Negativacao: TLabel
+        Left = 331
+        Top = 91
         Width = 74
         Height = 14
         Caption = 'Negativar T'#237'tulo'
@@ -346,9 +333,9 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
-      object Label16: TLabel
-        Left = 406
-        Top = 74
+      object Lb_Dias_Negativacao: TLabel
+        Left = 414
+        Top = 90
         Width = 38
         Height = 14
         Caption = 'Nr Dias '
@@ -359,80 +346,93 @@ inherited RegElectronicSlip: TRegElectronicSlip
         Font.Style = []
         ParentFont = False
       end
+      object Lb_Tx_Mora: TLabel
+        Left = 103
+        Top = 166
+        Width = 63
+        Height = 14
+        Caption = 'Mora/Dia (%)'
+        Font.Charset = ANSI_CHARSET
+        Font.Color = clNavy
+        Font.Height = -11
+        Font.Name = 'Arial'
+        Font.Style = []
+        ParentFont = False
+      end
       object Dblcb_Carteira: TComboBox
-        Left = 5
-        Top = 14
+        Left = 13
+        Top = 30
         Width = 201
         Height = 21
         TabOrder = 0
       end
       object E_Cedente_Convenio: TEdit
-        Left = 150
-        Top = 52
+        Left = 158
+        Top = 68
         Width = 134
         Height = 21
         TabOrder = 2
       end
       object E_Varia_Carteira: TEdit
-        Left = 419
-        Top = 52
+        Left = 427
+        Top = 68
         Width = 107
         Height = 21
         TabOrder = 4
       end
       object Cb_Modelo_Boleto: TComboBox
-        Left = 6
-        Top = 126
+        Left = 14
+        Top = 142
         Width = 141
         Height = 21
         Style = csDropDownList
         TabOrder = 10
       end
       object E_Local_Pagamento: TEdit
-        Left = 7
-        Top = 208
+        Left = 15
+        Top = 224
         Width = 553
         Height = 21
         TabOrder = 18
       end
       object E_Inst_Pagamento_1: TEdit
-        Left = 6
-        Top = 245
+        Left = 14
+        Top = 261
         Width = 553
         Height = 21
         TabOrder = 20
       end
       object E_Inst_Pagamento_2: TEdit
-        Left = 6
-        Top = 281
+        Left = 14
+        Top = 297
         Width = 553
         Height = 21
         TabOrder = 22
       end
       object E_Path_Remessa_Retorno: TEdit
-        Left = 6
-        Top = 465
+        Left = 14
+        Top = 441
         Width = 528
         Height = 21
         TabOrder = 19
       end
       object E_Tx_Multa: TEdit
-        Left = 340
-        Top = 165
+        Left = 348
+        Top = 181
         Width = 110
         Height = 21
         TabOrder = 16
       end
       object E_Tx_Juros: TEdit
-        Left = 5
-        Top = 165
+        Left = 13
+        Top = 181
         Width = 84
         Height = 21
         TabOrder = 12
       end
       object Cb_Protesto: TComboBox
-        Left = 97
-        Top = 90
+        Left = 105
+        Top = 106
         Width = 158
         Height = 21
         Style = csDropDownList
@@ -446,36 +446,36 @@ inherited RegElectronicSlip: TRegElectronicSlip
           '3 - N'#227'o protestar')
       end
       object DBMemo1: TMemo
-        Left = 5
-        Top = 358
+        Left = 13
+        Top = 334
         Width = 552
         Height = 90
         TabOrder = 21
       end
       object E_Tx_Mora: TEdit
-        Left = 91
-        Top = 165
+        Left = 99
+        Top = 181
         Width = 80
         Height = 21
         TabOrder = 13
       end
       object E_VL_Tarifa: TEdit
-        Left = 451
-        Top = 165
+        Left = 459
+        Top = 181
         Width = 110
         Height = 21
         TabOrder = 17
       end
       object E_Dias_Protesto: TEdit
-        Left = 258
-        Top = 90
+        Left = 266
+        Top = 106
         Width = 59
         Height = 21
         TabOrder = 7
       end
       object RG_Aceite: TRadioGroup
-        Left = 7
-        Top = 37
+        Left = 15
+        Top = 53
         Width = 137
         Height = 35
         Caption = 'Aceite'
@@ -492,22 +492,22 @@ inherited RegElectronicSlip: TRegElectronicSlip
         TabOrder = 1
       end
       object E_Tx_Desconto: TEdit
-        Left = 255
-        Top = 165
+        Left = 263
+        Top = 181
         Width = 83
         Height = 21
         TabOrder = 15
       end
       object E_VL_MORA_MIN: TEdit
-        Left = 173
-        Top = 165
+        Left = 181
+        Top = 181
         Width = 80
         Height = 21
         TabOrder = 14
       end
       object Cb_LayoutRemessa: TComboBox
-        Left = 5
-        Top = 90
+        Left = 13
+        Top = 106
         Width = 89
         Height = 21
         Style = csDropDownList
@@ -519,22 +519,22 @@ inherited RegElectronicSlip: TRegElectronicSlip
           'c400')
       end
       object E_CodTransmissao: TEdit
-        Left = 286
-        Top = 52
+        Left = 294
+        Top = 68
         Width = 131
         Height = 21
         TabOrder = 3
       end
       object E_POSTO_BENEF: TEdit
-        Left = 150
-        Top = 126
+        Left = 158
+        Top = 142
         Width = 98
         Height = 21
         TabOrder = 11
       end
       object Cb_Negativacao: TComboBox
-        Left = 323
-        Top = 90
+        Left = 331
+        Top = 106
         Width = 77
         Height = 21
         Style = csDropDownList
@@ -546,16 +546,12 @@ inherited RegElectronicSlip: TRegElectronicSlip
           'Sim')
       end
       object E_Dias_Negativacao: TEdit
-        Left = 406
-        Top = 90
+        Left = 414
+        Top = 106
         Width = 59
         Height = 21
         TabOrder = 9
       end
     end
-  end
-  inherited Menu: TMainMenu
-    Left = 304
-    Top = 40
   end
 end

--- a/view/module/operation/register/reg_electronic_slip.pas
+++ b/view/module/operation/register/reg_electronic_slip.pas
@@ -10,30 +10,29 @@ uses
 type
   TRegElectronicSlip = class(TBaseRegistry)
     Pnl_fundos: TPanel;
-    Label1: TLabel;
+    Lb_Carteira: TLabel;
     Sb_Carteira: TSpeedButton;
-    Label2: TLabel;
-    Label4: TLabel;
-    Label31: TLabel;
-    Label5: TLabel;
-    Label6: TLabel;
-    Label7: TLabel;
-    Label8: TLabel;
-    Label10: TLabel;
+    Lb_Cedente_Convenio: TLabel;
+    Lb_Varia_Carteira: TLabel;
+    Lb_Modelo_Boleto: TLabel;
+    Lb_Local_Pagamneto: TLabel;
+    Lb_Inst_Pagamento_1: TLabel;
+    Lb_Inst_Pagamento_2: TLabel;
+    Lb_IntrucaoAdicional: TLabel;
+    Lb_Remessa_Retorno: TLabel;
     Sb_Path_remessa: TSpeedButton;
-    Label11: TLabel;
-    Label12: TLabel;
-    Label13: TLabel;
-    Label14: TLabel;
-    Label15: TLabel;
-    Label_1: TLabel;
-    Label17: TLabel;
-    Label18: TLabel;
-    Label19: TLabel;
-    Label20: TLabel;
-    Label3: TLabel;
-    Label9: TLabel;
-    Label16: TLabel;
+    Lb_Tx_Multa: TLabel;
+    Lb_Tx_Juros: TLabel;
+    Lb_Protesto: TLabel;
+    Lb_Vl_Tarifa: TLabel;
+    Lb_Dias_Protesto: TLabel;
+    Lb_Tx_Desconto: TLabel;
+    Lb_Vl_Mora_Min: TLabel;
+    Lb_LayoutRemessa: TLabel;
+    Lb_CodTransmissao: TLabel;
+    Lb_Posto_Benef: TLabel;
+    Lb_Negativacao: TLabel;
+    Lb_Dias_Negativacao: TLabel;
     Dblcb_Carteira: TComboBox;
     E_Cedente_Convenio: TEdit;
     E_Varia_Carteira: TEdit;
@@ -57,6 +56,7 @@ type
     E_POSTO_BENEF: TEdit;
     Cb_Negativacao: TComboBox;
     E_Dias_Negativacao: TEdit;
+    Lb_Tx_Mora: TLabel;
   private
     { Private declarations }
   public

--- a/view/module/operation/register/reg_group_menu.dfm
+++ b/view/module/operation/register/reg_group_menu.dfm
@@ -69,7 +69,7 @@ inherited RegGroupMenu: TRegGroupMenu
       TabOrder = 0
       ExplicitWidth = 569
       ExplicitHeight = 201
-      object Label3: TLabel
+      object Lb_Descricao: TLabel
         Left = 72
         Top = 5
         Width = 100
@@ -82,7 +82,7 @@ inherited RegGroupMenu: TRegGroupMenu
         Font.Style = []
         ParentFont = False
       end
-      object Label1: TLabel
+      object Lb_Desconto: TLabel
         Left = 464
         Top = 5
         Width = 89
@@ -96,7 +96,7 @@ inherited RegGroupMenu: TRegGroupMenu
         Font.Style = []
         ParentFont = False
       end
-      object Label4: TLabel
+      object Lb_Sequencia: TLabel
         Left = 9
         Top = 5
         Width = 51

--- a/view/module/operation/register/reg_group_menu.pas
+++ b/view/module/operation/register/reg_group_menu.pas
@@ -11,9 +11,9 @@ uses
 type
   TRegGroupMenu = class(TBaseRegistry)
     pnl_fundos: TPanel;
-    Label3: TLabel;
-    Label1: TLabel;
-    Label4: TLabel;
+    Lb_Descricao: TLabel;
+    Lb_Desconto: TLabel;
+    Lb_Sequencia: TLabel;
     E_Descricao: TEdit;
     E_Vl_Desconto: TEdit;
     DBRG_Tamanhos: TRadioGroup;

--- a/view/module/operation/register/reg_subgroup_menu.dfm
+++ b/view/module/operation/register/reg_subgroup_menu.dfm
@@ -2,15 +2,13 @@ inherited RegSubgroupMenu: TRegSubgroupMenu
   Caption = 'Cadastro de SubGrupo'
   ClientHeight = 122
   ClientWidth = 552
-  ExplicitLeft = 3
-  ExplicitTop = 3
   ExplicitWidth = 564
   ExplicitHeight = 185
   TextHeight = 13
   inherited pnl_botao: TPanel
     Top = 58
     Width = 552
-    ExplicitTop = 55
+    ExplicitTop = 49
     ExplicitWidth = 546
     inherited SB_Inserir: TSpeedButton
       Left = -8
@@ -59,7 +57,7 @@ inherited RegSubgroupMenu: TRegSubgroupMenu
     Width = 552
     Height = 58
     ExplicitWidth = 546
-    ExplicitHeight = 55
+    ExplicitHeight = 49
     object pnl_fundos: TPanel
       Left = 2
       Top = 2
@@ -70,8 +68,8 @@ inherited RegSubgroupMenu: TRegSubgroupMenu
       BevelOuter = bvLowered
       TabOrder = 0
       ExplicitWidth = 542
-      ExplicitHeight = 51
-      object Label1: TLabel
+      ExplicitHeight = 45
+      object Lb_CodigoeDescricao: TLabel
         Left = 5
         Top = 5
         Width = 159
@@ -114,5 +112,9 @@ inherited RegSubgroupMenu: TRegSubgroupMenu
         TabOrder = 1
       end
     end
+  end
+  inherited Menu: TMainMenu
+    Left = 120
+    Top = 16
   end
 end

--- a/view/module/operation/register/reg_subgroup_menu.pas
+++ b/view/module/operation/register/reg_subgroup_menu.pas
@@ -10,7 +10,7 @@ uses
 type
   TRegSubgroupMenu = class(TBaseRegistry)
     pnl_fundos: TPanel;
-    Label1: TLabel;
+    Lb_CodigoeDescricao: TLabel;
     E_Codigo: TEdit;
     E_Descricao: TEdit;
   private

--- a/view/module/operation/register/sea_category.dfm
+++ b/view/module/operation/register/sea_category.dfm
@@ -9,14 +9,11 @@ inherited SeaCategory: TSeaCategory
     Top = 81
     Width = 572
     Height = 286
-    ExplicitTop = 65
+    ExplicitTop = 81
     ExplicitWidth = 566
-    ExplicitHeight = 293
+    ExplicitHeight = 277
     inherited Lb_ResultadoPesquisa: TLabel
       Width = 568
-      ExplicitLeft = 9
-      ExplicitTop = 31
-      ExplicitWidth = 568
     end
     inherited DBG_Pesquisa: TDBGrid
       Width = 476
@@ -26,7 +23,7 @@ inherited SeaCategory: TSeaCategory
       Left = 478
       Height = 268
       ExplicitLeft = 472
-      ExplicitHeight = 275
+      ExplicitHeight = 259
       inherited Sb_Sair_0: TSpeedButton
         Top = 205
         ExplicitTop = 221
@@ -48,7 +45,7 @@ inherited SeaCategory: TSeaCategory
   inherited Pnl_Parametros: TPanel
     Width = 572
     Height = 72
-    ExplicitWidth = 572
+    ExplicitWidth = 566
     ExplicitHeight = 72
     object GroupBox2: TGroupBox
       Left = 2
@@ -64,8 +61,8 @@ inherited SeaCategory: TSeaCategory
       Font.Style = []
       ParentFont = False
       TabOrder = 0
-      ExplicitTop = -5
-      object Label28: TLabel
+      ExplicitWidth = 562
+      object Lb_Descricao: TLabel
         Left = 57
         Top = 16
         Width = 49
@@ -78,7 +75,7 @@ inherited SeaCategory: TSeaCategory
         Font.Style = []
         ParentFont = False
       end
-      object Label3: TLabel
+      object Lb_BuscaCodigo: TLabel
         Left = 10
         Top = 16
         Width = 33
@@ -106,7 +103,7 @@ inherited SeaCategory: TSeaCategory
         TabOrder = 1
       end
       object E_BuscaCodigo: TEdit
-        Left = 7
+        Left = 3
         Top = 32
         Width = 49
         Height = 22
@@ -120,5 +117,9 @@ inherited SeaCategory: TSeaCategory
         TabOrder = 0
       end
     end
+  end
+  inherited Menu: TMainMenu
+    Left = 80
+    Top = 144
   end
 end

--- a/view/module/operation/register/sea_category.pas
+++ b/view/module/operation/register/sea_category.pas
@@ -10,8 +10,8 @@ uses
 type
   TSeaCategory = class(TBaseSearch)
     GroupBox2: TGroupBox;
-    Label28: TLabel;
-    Label3: TLabel;
+    Lb_Descricao: TLabel;
+    Lb_BuscaCodigo: TLabel;
     SeaCategory: TEdit;
     E_BuscaCodigo: TEdit;
   private

--- a/view/module/operation/register/sea_electronic_slip.dfm
+++ b/view/module/operation/register/sea_electronic_slip.dfm
@@ -1,44 +1,44 @@
 inherited SeaElectronicSlip: TSeaElectronicSlip
-  Caption = 'Cadastro de Cobran'#231'a em Boleto'
-  ClientHeight = 352
+  Caption = 'Pesquisa de Cobran'#231'a em boleto'
+  ClientHeight = 586
   ClientWidth = 575
   ExplicitWidth = 587
-  ExplicitHeight = 415
+  ExplicitHeight = 649
   TextHeight = 13
   inherited Pnl_Fundo: TPanel
     Top = 71
     Width = 569
-    Height = 278
+    Height = 512
     ExplicitTop = 71
     ExplicitWidth = 563
-    ExplicitHeight = 269
+    ExplicitHeight = 503
     inherited Lb_ResultadoPesquisa: TLabel
       Width = 565
     end
     inherited DBG_Pesquisa: TDBGrid
       Width = 473
-      Height = 260
+      Height = 494
     end
     inherited pnl_pesq_right: TPanel
       Left = 475
-      Height = 260
+      Height = 494
       ExplicitLeft = 469
-      ExplicitHeight = 251
+      ExplicitHeight = 485
       inherited Sb_Sair_0: TSpeedButton
-        Top = 197
-        ExplicitTop = 197
+        Top = 431
+        ExplicitTop = 431
       end
       inherited SB_Visualizar: TSpeedButton
-        Top = 134
-        ExplicitTop = 134
+        Top = 368
+        ExplicitTop = 368
       end
       inherited SB_Buscar: TSpeedButton
-        Top = 71
-        ExplicitTop = 71
+        Top = 305
+        ExplicitTop = 305
       end
       inherited SB_Cadastrar: TSpeedButton
-        Top = 8
-        ExplicitTop = 8
+        Top = 242
+        ExplicitTop = 242
       end
     end
   end
@@ -62,8 +62,8 @@ inherited SeaElectronicSlip: TSeaElectronicSlip
       ParentFont = False
       TabOrder = 0
       ExplicitWidth = 559
-      object Label55: TLabel
-        Left = 3
+      object Lb_BuscaBanco: TLabel
+        Left = 5
         Top = 17
         Width = 31
         Height = 14
@@ -76,16 +76,16 @@ inherited SeaElectronicSlip: TSeaElectronicSlip
         ParentFont = False
       end
       object E_BuscaBanco: TEdit
-        Left = 3
-        Top = 29
-        Width = 559
+        Left = 5
+        Top = 32
+        Width = 557
         Height = 22
         TabOrder = 0
       end
     end
   end
   inherited Menu: TMainMenu
-    Left = 56
-    Top = 88
+    Left = 96
+    Top = 65528
   end
 end

--- a/view/module/operation/register/sea_electronic_slip.pas
+++ b/view/module/operation/register/sea_electronic_slip.pas
@@ -10,7 +10,7 @@ uses
 type
   TSeaElectronicSlip = class(TBaseSearch)
     Grp_Parametros: TGroupBox;
-    Label55: TLabel;
+    Lb_BuscaBanco: TLabel;
     E_BuscaBanco: TEdit;
   private
     { Private declarations }

--- a/view/module/operation/register/sea_group_menu.dfm
+++ b/view/module/operation/register/sea_group_menu.dfm
@@ -1,14 +1,16 @@
 inherited SeaGroupMenu: TSeaGroupMenu
   Caption = 'Pesquisa de Grupo e SubGrupo do Card'#225'pio'
-  ClientHeight = 424
+  ClientHeight = 438
   ClientWidth = 594
+  ExplicitLeft = 3
+  ExplicitTop = 3
   ExplicitWidth = 606
-  ExplicitHeight = 487
+  ExplicitHeight = 501
   TextHeight = 13
   inherited Pnl_Fundo: TPanel
     Top = 79
     Width = 588
-    Height = 342
+    Height = 356
     ExplicitTop = 79
     ExplicitWidth = 582
     ExplicitHeight = 333
@@ -17,33 +19,33 @@ inherited SeaGroupMenu: TSeaGroupMenu
     end
     inherited DBG_Pesquisa: TDBGrid
       Width = 492
-      Height = 324
+      Height = 338
     end
     inherited pnl_pesq_right: TPanel
       Left = 494
-      Height = 324
+      Height = 338
       ExplicitLeft = 488
       ExplicitHeight = 315
       inherited Sb_Sair_0: TSpeedButton
-        Top = 261
+        Top = 275
         ExplicitTop = 330
       end
       inherited SB_Visualizar: TSpeedButton
-        Top = 198
+        Top = 212
         ExplicitTop = 267
       end
       inherited SB_Buscar: TSpeedButton
-        Top = 135
+        Top = 149
         ExplicitTop = 204
       end
       inherited SB_Cadastrar: TSpeedButton
-        Top = 72
+        Top = 86
         ExplicitTop = 141
       end
     end
     object ChBx_Grupo: TCheckBox
-      Left = 488
-      Top = 16
+      Left = 500
+      Top = 0
       Width = 89
       Height = 17
       Anchors = [akTop, akRight]
@@ -55,7 +57,6 @@ inherited SeaGroupMenu: TSeaGroupMenu
       Font.Style = []
       ParentFont = False
       TabOrder = 2
-      ExplicitLeft = 482
     end
   end
   inherited Pnl_Parametros: TPanel
@@ -78,7 +79,7 @@ inherited SeaGroupMenu: TSeaGroupMenu
       ParentFont = False
       TabOrder = 0
       ExplicitWidth = 578
-      object Label28: TLabel
+      object Lb_grupo: TLabel
         Left = 11
         Top = 16
         Width = 30
@@ -91,7 +92,7 @@ inherited SeaGroupMenu: TSeaGroupMenu
         Font.Style = []
         ParentFont = False
       end
-      object Label2: TLabel
+      object Lb_subgrupo: TLabel
         Left = 291
         Top = 16
         Width = 49

--- a/view/module/operation/register/sea_group_menu.pas
+++ b/view/module/operation/register/sea_group_menu.pas
@@ -10,8 +10,8 @@ uses
 type
   TSeaGroupMenu = class(TBaseSearch)
     GroupBox2: TGroupBox;
-    Label28: TLabel;
-    Label2: TLabel;
+    Lb_grupo: TLabel;
+    Lb_subgrupo: TLabel;
     E_BuscaGrupo: TEdit;
     E_BuscaSubGrupo: TEdit;
     ChBx_Grupo: TCheckBox;


### PR DESCRIPTION
Aqui está a copia das seguintes telas para o novo padrão
electronic_slip
banner_site
group_menu
subgroup_menu
category
Elas estão no seguite diretório:
gestaoerp\view\module\operation\register